### PR TITLE
Add getAuthorIdent() to CommitImpact

### DIFF
--- a/org.gitective.core/src/main/java/org/gitective/core/filter/commit/CommitImpact.java
+++ b/org.gitective.core/src/main/java/org/gitective/core/filter/commit/CommitImpact.java
@@ -26,8 +26,9 @@ import static org.eclipse.jgit.lib.Constants.OBJECT_ID_LENGTH;
 import java.util.Arrays;
 import java.util.Comparator;
 
-import org.eclipse.jgit.lib.AnyObjectId;
 import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.util.NB;
 
 /**
@@ -80,6 +81,8 @@ public class CommitImpact {
 
 	private final byte[] commit;
 
+	private final PersonIdent authorIndent;
+
 	/**
 	 * Create impact
 	 *
@@ -88,9 +91,10 @@ public class CommitImpact {
 	 * @param edit
 	 * @param delete
 	 */
-	public CommitImpact(AnyObjectId commit, int add, int edit, int delete) {
+	public CommitImpact(RevCommit commit, int add, int edit, int delete) {
 		this.commit = new byte[OBJECT_ID_LENGTH];
 		commit.copyRawTo(this.commit, 0);
+		this.authorIndent = commit.getAuthorIdent();
 		this.add = add;
 		this.edit = edit;
 		this.delete = delete;
@@ -122,6 +126,13 @@ public class CommitImpact {
 	 */
 	public ObjectId getCommit() {
 		return ObjectId.fromRaw(commit);
+	}
+
+	/**
+	 * @return author identification
+	 */
+	public PersonIdent getAuthorIndent() {
+		return authorIndent;
 	}
 
 	public String toString() {


### PR DESCRIPTION
git-reports uses this and it was previously available as
getCommit().getAuthorIdent() before commit
c7692d679573d5703efa3424a553ab47d9de0de3.
