### PR TITLE
Fixes for recursion and deleted blobs for getLastCommits

### DIFF
--- a/org.gitective.core/src/main/java/org/gitective/core/CommitUtils.java
+++ b/org.gitective.core/src/main/java/org/gitective/core/CommitUtils.java
@@ -451,10 +451,14 @@ public abstract class CommitUtils {
 		RevCommit commit;
 		while ((commit = revWalk.next()) != null) {
 			TreeWalk diffWalk = TreeUtils.diffWithParents(revWalk, commit);
+			diffWalk.setRecursive(true);
 			while (diffWalk.next()) {
 				String path = diffWalk.getPathString();
 				RevCommit blobCommit = commits.get(path);
 				if (blobCommit != null)
+					continue;
+				if (!commits.containsKey(path))
+					// deleted blob
 					continue;
 				commits.put(path, commit);
 				blobCount--;


### PR DESCRIPTION
I found two bugs in the algorithm (which works wonderfully!).  Without diffWalk recursion you end up with a map full of mostly null values and without the key check deleted blobs are incorrectly added to the map.
