### PR TITLE
Fix TreeUtils.visit() to recurse into subtrees correctly

### DIFF
--- a/org.gitective.core/src/main/java/org/gitective/core/TreeUtils.java
+++ b/org.gitective.core/src/main/java/org/gitective/core/TreeUtils.java
@@ -443,6 +443,7 @@ public abstract class TreeUtils {
 					return false;
 			}
 
+			walk.getObjectId(id, 0);
 			if (!visitor.accept(walk.getFileMode(0),
 					path, walk.getNameString(), id))
 				return false;

--- a/org.gitective.core/src/main/java/org/gitective/core/TreeUtils.java
+++ b/org.gitective.core/src/main/java/org/gitective/core/TreeUtils.java
@@ -414,24 +414,38 @@ public abstract class TreeUtils {
 			throw new IllegalArgumentException(Assert.formatNotNull("Visitor"));
 
 		final TreeWalk walk = new TreeWalk(repository);
+		walk.setPostOrderTraversal(true);
 		final MutableObjectId id = new MutableObjectId();
-		String path = null;
 		try {
 			walk.addTree(treeId);
-			while (walk.next()) {
-				walk.getObjectId(id, 0);
-				if (!visitor.accept(walk.getFileMode(0), path,
-						walk.getNameString(), id))
-					return false;
-				if (walk.isSubtree()) {
-					path = walk.getPathString();
-					walk.enterSubtree();
-				}
-			}
+			if (!visit(repository, walk, id, null, visitor))
+				return false;
 		} catch (IOException e) {
 			throw new GitException(e, repository);
 		} finally {
 			walk.release();
+		}
+		return true;
+	}
+
+	private static boolean visit(final Repository repository,
+			final TreeWalk walk, final MutableObjectId id,
+			final String path, final ITreeVisitor visitor) throws IOException {
+
+		while (walk.next()) {
+			if (walk.isPostChildren())
+				break;
+
+			if (walk.isSubtree()) {
+				final String subTreePath = walk.getPathString();
+				walk.enterSubtree();
+				if (!visit(repository, walk, id, subTreePath, visitor))
+					return false;
+			}
+
+			if (!visitor.accept(walk.getFileMode(0),
+					path, walk.getNameString(), id))
+				return false;
 		}
 		return true;
 	}

--- a/org.gitective.core/src/test/java/org/gitective/tests/TreeUtilsTest.java
+++ b/org.gitective.core/src/test/java/org/gitective/tests/TreeUtilsTest.java
@@ -23,6 +23,7 @@ package org.gitective.tests;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -403,11 +404,12 @@ public class TreeUtilsTest extends GitTestCase {
 	 */
 	@Test
 	public void visit() throws Exception {
-		RevCommit commit = add("d/f.txt", "content");
+		RevCommit commit = add(
+				Arrays.asList("test.txt", "foo/bar.txt", "foo/baz/qux.txt"),
+				Arrays.asList("x", "x", "x"));
 		final AtomicInteger files = new AtomicInteger(0);
 		final AtomicInteger folders = new AtomicInteger(0);
-		final List<String> names = new ArrayList<String>();
-		final List<String> paths = new ArrayList<String>();
+		final List<String> fullPaths = new ArrayList<String>();
 		assertTrue(TreeUtils.visit(new FileRepository(testRepo),
 				commit.getTree(), new ITreeVisitor() {
 
@@ -417,18 +419,17 @@ public class TreeUtilsTest extends GitTestCase {
 							files.incrementAndGet();
 						if (mode == FileMode.TREE)
 							folders.incrementAndGet();
-						names.add(name);
-						if (path != null)
-							paths.add(path);
+						fullPaths.add((path != null) ? (path + "/" + name) : name);
 						return true;
 					}
 				}));
-		assertEquals(1, files.get());
-		assertEquals(1, folders.get());
-		assertEquals(2, names.size());
-		assertTrue(names.contains("d"));
-		assertTrue(names.contains("f.txt"));
-		assertEquals(1, paths.size());
-		assertTrue(paths.contains("d"));
+		assertEquals(3, files.get());
+		assertEquals(2, folders.get());
+		assertEquals(5, fullPaths.size());
+		assertTrue(fullPaths.contains("test.txt"));
+		assertTrue(fullPaths.contains("foo"));
+		assertTrue(fullPaths.contains("foo/bar.txt"));
+		assertTrue(fullPaths.contains("foo/baz"));
+		assertTrue(fullPaths.contains("foo/baz/qux.txt"));
 	}
 }

--- a/org.gitective.core/src/test/java/org/gitective/tests/TreeUtilsTest.java
+++ b/org.gitective.core/src/test/java/org/gitective/tests/TreeUtilsTest.java
@@ -410,6 +410,7 @@ public class TreeUtilsTest extends GitTestCase {
 		final AtomicInteger files = new AtomicInteger(0);
 		final AtomicInteger folders = new AtomicInteger(0);
 		final List<String> fullPaths = new ArrayList<String>();
+		final List<AnyObjectId> ids = new ArrayList<AnyObjectId>();
 		assertTrue(TreeUtils.visit(new FileRepository(testRepo),
 				commit.getTree(), new ITreeVisitor() {
 
@@ -420,6 +421,7 @@ public class TreeUtilsTest extends GitTestCase {
 						if (mode == FileMode.TREE)
 							folders.incrementAndGet();
 						fullPaths.add((path != null) ? (path + "/" + name) : name);
+						ids.add(id);
 						return true;
 					}
 				}));
@@ -431,5 +433,6 @@ public class TreeUtilsTest extends GitTestCase {
 		assertTrue(fullPaths.contains("foo/bar.txt"));
 		assertTrue(fullPaths.contains("foo/baz"));
 		assertTrue(fullPaths.contains("foo/baz/qux.txt"));
+		assertFalse(ids.contains(ObjectId.zeroId()));
 	}
 }


### PR DESCRIPTION
Hi,

I've fixed TreeUtils.visit() so that it recurses into subtrees correctly. Before the fix it would never notice when tree traversal had exited a subtree, resulting in wrong parameters passed to the visitor. I've also modified the test so that it tests against this.

Cheers,

Maik
