### PR TITLE
fixes FileRepository.java location

### DIFF
--- a/org.gitective.core/src/main/java/org/gitective/core/RepositoryService.java
+++ b/org.gitective.core/src/main/java/org/gitective/core/RepositoryService.java
@@ -28,7 +28,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.eclipse.jgit.lib.Repository;
-import org.eclipse.jgit.storage.file.FileRepository;
+import org.eclipse.jgit.internal.storage.file.FileRepository;
 
 /**
  * Base service class for working with one or more {@link Repository} instances.

--- a/org.gitective.core/src/test/java/org/gitective/tests/BadRepository.java
+++ b/org.gitective.core/src/test/java/org/gitective/tests/BadRepository.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 
 import org.eclipse.jgit.lib.BaseRepositoryBuilder;
 import org.eclipse.jgit.lib.RefDatabase;
-import org.eclipse.jgit.storage.file.FileRepository;
+import org.eclipse.jgit.internal.storage.file.FileRepository;
 
 /**
  * Repository that has a bad ref database

--- a/org.gitective.core/src/test/java/org/gitective/tests/BlobUtilsTest.java
+++ b/org.gitective.core/src/test/java/org/gitective/tests/BlobUtilsTest.java
@@ -41,7 +41,7 @@ import org.eclipse.jgit.lib.ObjectLoader;
 import org.eclipse.jgit.lib.ObjectStream;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.eclipse.jgit.storage.file.FileRepository;
+import org.eclipse.jgit.internal.storage.file.FileRepository;
 import org.gitective.core.BlobUtils;
 import org.gitective.core.CommitFinder;
 import org.gitective.core.GitException;

--- a/org.gitective.core/src/test/java/org/gitective/tests/CommitBaseTest.java
+++ b/org.gitective.core/src/test/java/org/gitective/tests/CommitBaseTest.java
@@ -24,7 +24,7 @@ package org.gitective.tests;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.eclipse.jgit.storage.file.FileRepository;
+import org.eclipse.jgit.internal.storage.file.FileRepository;
 import org.gitective.core.CommitFinder;
 import org.gitective.core.CommitUtils;
 import org.gitective.core.filter.commit.CommitListFilter;
@@ -40,7 +40,7 @@ public class CommitBaseTest extends GitTestCase {
 	/**
 	 * Test getting the base commit of a branch and master and then walking
 	 * between the tip of the branch and its branch point.
-	 * 
+	 *
 	 * @throws Exception
 	 */
 	@Test

--- a/org.gitective.core/src/test/java/org/gitective/tests/CommitTreeFilterTest.java
+++ b/org.gitective.core/src/test/java/org/gitective/tests/CommitTreeFilterTest.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.jgit.lib.Repository;
-import org.eclipse.jgit.storage.file.FileRepository;
+import org.eclipse.jgit.internal.storage.file.FileRepository;
 import org.eclipse.jgit.treewalk.TreeWalk;
 import org.gitective.core.filter.tree.BaseTreeFilter;
 import org.gitective.core.filter.tree.CommitTreeFilter;

--- a/org.gitective.core/src/test/java/org/gitective/tests/CommitUtilsTest.java
+++ b/org.gitective.core/src/test/java/org/gitective/tests/CommitUtilsTest.java
@@ -29,7 +29,7 @@ import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.eclipse.jgit.storage.file.FileRepository;
+import org.eclipse.jgit.internal.storage.file.FileRepository;
 import org.gitective.core.CommitUtils;
 import org.gitective.core.GitException;
 import org.junit.Test;

--- a/org.gitective.core/src/test/java/org/gitective/tests/CursorTest.java
+++ b/org.gitective.core/src/test/java/org/gitective/tests/CursorTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.filter.RevFilter;
-import org.eclipse.jgit.storage.file.FileRepository;
+import org.eclipse.jgit.internal.storage.file.FileRepository;
 import org.gitective.core.CommitFinder;
 import org.gitective.core.CommitUtils;
 import org.gitective.core.filter.commit.AndCommitFilter;
@@ -42,7 +42,7 @@ public class CursorTest extends GitTestCase {
 
 	/**
 	 * Test traversing commits in chunks
-	 * 
+	 *
 	 * @throws Exception
 	 */
 	@Test
@@ -76,7 +76,7 @@ public class CursorTest extends GitTestCase {
 
 	/**
 	 * Test clone of {@link CommitCursorFilter}
-	 * 
+	 *
 	 * @throws Exception
 	 */
 	@Test

--- a/org.gitective.core/src/test/java/org/gitective/tests/GitExceptionTest.java
+++ b/org.gitective.core/src/test/java/org/gitective/tests/GitExceptionTest.java
@@ -23,7 +23,7 @@ package org.gitective.tests;
 
 import java.io.IOException;
 
-import org.eclipse.jgit.storage.file.FileRepository;
+import org.eclipse.jgit.internal.storage.file.FileRepository;
 import org.gitective.core.GitException;
 import org.junit.Test;
 

--- a/org.gitective.core/src/test/java/org/gitective/tests/LastCommitDiffFilterTest.java
+++ b/org.gitective.core/src/test/java/org/gitective/tests/LastCommitDiffFilterTest.java
@@ -24,7 +24,7 @@ package org.gitective.tests;
 import java.util.Map;
 
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.eclipse.jgit.storage.file.FileRepository;
+import org.eclipse.jgit.internal.storage.file.FileRepository;
 import org.gitective.core.CommitFinder;
 import org.gitective.core.CommitUtils;
 import org.gitective.core.filter.commit.LastCommitDiffFilter;

--- a/org.gitective.core/src/test/java/org/gitective/tests/LatestTest.java
+++ b/org.gitective.core/src/test/java/org/gitective/tests/LatestTest.java
@@ -22,7 +22,7 @@
 package org.gitective.tests;
 
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.eclipse.jgit.storage.file.FileRepository;
+import org.eclipse.jgit.internal.storage.file.FileRepository;
 import org.gitective.core.CommitUtils;
 import org.junit.Test;
 

--- a/org.gitective.core/src/test/java/org/gitective/tests/MultiRepoTest.java
+++ b/org.gitective.core/src/test/java/org/gitective/tests/MultiRepoTest.java
@@ -24,7 +24,7 @@ package org.gitective.tests;
 import java.io.File;
 
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.eclipse.jgit.storage.file.FileRepository;
+import org.eclipse.jgit.internal.storage.file.FileRepository;
 import org.gitective.core.CommitFinder;
 import org.gitective.core.filter.commit.CommitCountFilter;
 import org.junit.Test;
@@ -36,7 +36,7 @@ public class MultiRepoTest extends GitTestCase {
 
 	/**
 	 * Test service constructors
-	 * 
+	 *
 	 * @throws Exception
 	 */
 	@Test
@@ -48,7 +48,7 @@ public class MultiRepoTest extends GitTestCase {
 
 	/**
 	 * Test search two repos from same service
-	 * 
+	 *
 	 * @throws Exception
 	 */
 	@Test

--- a/org.gitective.core/src/test/java/org/gitective/tests/RepositoryUtilsTest.java
+++ b/org.gitective.core/src/test/java/org/gitective/tests/RepositoryUtilsTest.java
@@ -33,7 +33,7 @@ import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.lib.RefUpdate;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.eclipse.jgit.storage.file.FileRepository;
+import org.eclipse.jgit.internal.storage.file.FileRepository;
 import org.eclipse.jgit.transport.RemoteConfig;
 import org.eclipse.jgit.transport.URIish;
 import org.gitective.core.RepositoryUtils;

--- a/org.gitective.core/src/test/java/org/gitective/tests/TreeUtilsTest.java
+++ b/org.gitective.core/src/test/java/org/gitective/tests/TreeUtilsTest.java
@@ -38,7 +38,7 @@ import org.eclipse.jgit.lib.FileMode;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.eclipse.jgit.storage.file.FileRepository;
+import org.eclipse.jgit.internal.storage.file.FileRepository;
 import org.eclipse.jgit.treewalk.TreeWalk;
 import org.gitective.core.BlobUtils;
 import org.gitective.core.TreeUtils;


### PR DESCRIPTION
The current (unstable version of JGit) seems to have changed the location of some things.  FileRepository is now in: org/eclipse/jgit/internal/storage/file/

I would suggest waiting on merging this until they release the next stable version (just in case they change something else) but it's up to you.

Cheers.
