### PR TITLE
Upgrade to jgit 3.0 since it's released.

### DIFF
--- a/org.gitective.core/pom.xml
+++ b/org.gitective.core/pom.xml
@@ -190,7 +190,7 @@
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>
 			<artifactId>org.eclipse.jgit</artifactId>
-			<version>2.0.0.201206130900-r</version>
+			<version>3.0.0.201306101825-r</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/org.gitective.core/pom.xml
+++ b/org.gitective.core/pom.xml
@@ -9,7 +9,7 @@
 
 	<groupId>org.gitective</groupId>
 	<artifactId>gitective-core</artifactId>
-	<version>0.9.10-SNAPSHOT</version>
+	<version>0.9.10</version>
 	<name>gitective core</name>
 	<description>gitective core library</description>
 	<url>http://gitective.org</url>

--- a/org.gitective.core/src/main/java/org/gitective/core/RepositoryService.java
+++ b/org.gitective.core/src/main/java/org/gitective/core/RepositoryService.java
@@ -27,8 +27,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import org.eclipse.jgit.internal.storage.file.FileRepository;
 import org.eclipse.jgit.lib.Repository;
-import org.eclipse.jgit.storage.file.FileRepository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 
 /**
  * Base service class for working with one or more {@link Repository} instances.
@@ -81,8 +82,12 @@ public class RepositoryService {
 		final int length = gitDirs.length;
 		repositories = new Repository[length];
 		try {
-			for (int i = 0; i < length; i++)
-				repositories[i] = new FileRepository(gitDirs[i]);
+			for (int i = 0; i < length; i++) {
+        repositories[i] = new FileRepositoryBuilder()
+          .setGitDir(gitDirs[i])
+          .readEnvironment()
+          .build();
+      }
 		} catch (IOException e) {
 			throw new IllegalArgumentException(e);
 		}
@@ -126,9 +131,9 @@ public class RepositoryService {
 		try {
 			for (Object repo : repositories)
 				if (repo instanceof String)
-					created.add(new FileRepository((String) repo));
+					created.add(new FileRepositoryBuilder().setGitDir(new File((String)repo)).readEnvironment().build());
 				else if (repo instanceof File)
-					created.add(new FileRepository((File) repo));
+					created.add(new FileRepositoryBuilder().setGitDir((File)repo).readEnvironment().build());
 				else if (repo instanceof Repository)
 					created.add((Repository) repo);
 		} catch (IOException e) {

--- a/org.gitective.core/src/test/java/org/gitective/tests/BadRepository.java
+++ b/org.gitective.core/src/test/java/org/gitective/tests/BadRepository.java
@@ -24,9 +24,9 @@ package org.gitective.tests;
 import java.io.File;
 import java.io.IOException;
 
+import org.eclipse.jgit.internal.storage.file.FileRepository;
 import org.eclipse.jgit.lib.BaseRepositoryBuilder;
 import org.eclipse.jgit.lib.RefDatabase;
-import org.eclipse.jgit.storage.file.FileRepository;
 
 /**
  * Repository that has a bad ref database

--- a/org.gitective.core/src/test/java/org/gitective/tests/CommitBaseTest.java
+++ b/org.gitective.core/src/test/java/org/gitective/tests/CommitBaseTest.java
@@ -24,7 +24,7 @@ package org.gitective.tests;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.eclipse.jgit.storage.file.FileRepository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.gitective.core.CommitFinder;
 import org.gitective.core.CommitUtils;
 import org.gitective.core.filter.commit.CommitListFilter;
@@ -50,7 +50,10 @@ public class CommitBaseTest extends GitTestCase {
 		RevCommit commit2 = add("file.txt", "edit 1");
 		RevCommit commit3 = add("file.txt", "edit 2");
 
-		Repository repo = new FileRepository(testRepo);
+    Repository repo = new FileRepositoryBuilder()
+      .setGitDir(testRepo)
+      .readEnvironment()
+      .build();
 		RevCommit base = CommitUtils
 				.getBase(repo, Constants.MASTER, "release1");
 		assertEquals(commit1, base);

--- a/org.gitective.core/src/test/java/org/gitective/tests/CommitTreeFilterTest.java
+++ b/org.gitective.core/src/test/java/org/gitective/tests/CommitTreeFilterTest.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.jgit.lib.Repository;
-import org.eclipse.jgit.storage.file.FileRepository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.eclipse.jgit.treewalk.TreeWalk;
 import org.gitective.core.filter.tree.BaseTreeFilter;
 import org.gitective.core.filter.tree.CommitTreeFilter;
@@ -88,7 +88,7 @@ public class CommitTreeFilterTest extends GitTestCase {
 			}
 		};
 		CommitTreeFilter filter = new CommitTreeFilter(treeFilter);
-		Repository fileRepo = new FileRepository(testRepo);
+		Repository fileRepo = new FileRepositoryBuilder().setGitDir(testRepo).build();
 		filter.setRepository(fileRepo);
 		assertNotNull(repo.get());
 		assertEquals(fileRepo.getDirectory(), repo.get().getDirectory());

--- a/org.gitective.core/src/test/java/org/gitective/tests/CommitUtilsTest.java
+++ b/org.gitective.core/src/test/java/org/gitective/tests/CommitUtilsTest.java
@@ -24,12 +24,10 @@ package org.gitective.tests;
 import java.io.IOException;
 import java.util.Collection;
 
-import org.eclipse.jgit.lib.Constants;
-import org.eclipse.jgit.lib.ObjectId;
-import org.eclipse.jgit.lib.Ref;
-import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.internal.storage.file.FileRepository;
+import org.eclipse.jgit.lib.*;
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.eclipse.jgit.storage.file.FileRepository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.gitective.core.CommitUtils;
 import org.gitective.core.GitException;
 import org.junit.Test;
@@ -58,7 +56,7 @@ public class CommitUtilsTest extends GitTestCase {
 		add("a.txt", "a");
 		RevCommit commit = add("test.txt", "content");
 		tag(testRepo, "tag1");
-		Repository repo = new FileRepository(testRepo);
+		Repository repo = new FileRepositoryBuilder().setGitDir(testRepo).build();
 		RevCommit refCommit = CommitUtils.getRef(repo, "tag1");
 		assertNotNull(refCommit);
 		assertEquals(commit, refCommit);
@@ -75,7 +73,7 @@ public class CommitUtilsTest extends GitTestCase {
 	 */
 	@Test
 	public void invalidRef() throws Exception {
-		RevCommit commit = CommitUtils.getRef(new FileRepository(testRepo),
+		RevCommit commit = CommitUtils.getRef(new FileRepositoryBuilder().setGitDir(testRepo).build(),
 				"notatag");
 		assertNull(commit);
 	}
@@ -90,7 +88,7 @@ public class CommitUtilsTest extends GitTestCase {
 		add("a.txt", "a");
 		RevCommit commit = add("test.txt", "content");
 		Ref ref = branch(testRepo, "branch1");
-		Repository repo = new FileRepository(testRepo);
+		Repository repo = new FileRepositoryBuilder().setGitDir(testRepo).build();
 		RevCommit refCommit = CommitUtils.getRef(repo, ref);
 		assertNotNull(refCommit);
 		assertEquals(commit, refCommit);
@@ -123,7 +121,7 @@ public class CommitUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void getCommitWithNullObjectId() throws Exception {
-		CommitUtils.getCommit(new FileRepository(testRepo), (ObjectId) null);
+		CommitUtils.getCommit(new FileRepositoryBuilder().setGitDir(testRepo).build(), (ObjectId) null);
 	}
 
 	/**
@@ -133,7 +131,7 @@ public class CommitUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void getCommitWithNullRevision() throws Exception {
-		CommitUtils.getCommit(new FileRepository(testRepo), (String) null);
+		CommitUtils.getCommit(new FileRepositoryBuilder().setGitDir(testRepo).build(), (String) null);
 	}
 
 	/**
@@ -143,7 +141,7 @@ public class CommitUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void getCommitWithEmptyRevision() throws Exception {
-		CommitUtils.getCommit(new FileRepository(testRepo), "");
+		CommitUtils.getCommit(new FileRepositoryBuilder().setGitDir(testRepo).build(), "");
 	}
 
 	/**
@@ -169,7 +167,7 @@ public class CommitUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void getBaseWithNullIds() throws Exception {
-		CommitUtils.getBase(new FileRepository(testRepo), (ObjectId[]) null);
+		CommitUtils.getBase(new FileRepositoryBuilder().setGitDir(testRepo).build(), (ObjectId[]) null);
 	}
 
 	/**
@@ -179,7 +177,7 @@ public class CommitUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void getBaseWithEmptyIds() throws Exception {
-		CommitUtils.getBase(new FileRepository(testRepo), new ObjectId[0]);
+		CommitUtils.getBase(new FileRepositoryBuilder().setGitDir(testRepo).build(), new ObjectId[0]);
 	}
 
 	/**
@@ -189,7 +187,7 @@ public class CommitUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void getBaseWithNullRevisions() throws Exception {
-		CommitUtils.getBase(new FileRepository(testRepo), (String[]) null);
+		CommitUtils.getBase(new FileRepositoryBuilder().setGitDir(testRepo).build(), (String[]) null);
 	}
 
 	/**
@@ -199,7 +197,7 @@ public class CommitUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void getBaseWithEmptyRevisions() throws Exception {
-		CommitUtils.getBase(new FileRepository(testRepo), new String[0]);
+		CommitUtils.getBase(new FileRepositoryBuilder().setGitDir(testRepo).build(), new String[0]);
 	}
 
 	/**
@@ -209,7 +207,7 @@ public class CommitUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = GitException.class)
 	public void getBaseWithUnknownRevision() throws Exception {
-		CommitUtils.getBase(new FileRepository(testRepo), "notaref");
+		CommitUtils.getBase(new FileRepositoryBuilder().setGitDir(testRepo).build(), "notaref");
 	}
 
 	/**
@@ -235,7 +233,7 @@ public class CommitUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void getRefWithNullRef() throws Exception {
-		CommitUtils.getRef(new FileRepository(testRepo), (Ref) null);
+		CommitUtils.getRef(new FileRepositoryBuilder().setGitDir(testRepo).build(), (Ref) null);
 	}
 
 	/**
@@ -245,7 +243,7 @@ public class CommitUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void getRefWithNullRefName() throws Exception {
-		CommitUtils.getRef(new FileRepository(testRepo), (String) null);
+		CommitUtils.getRef(new FileRepositoryBuilder().setGitDir(testRepo).build(), (String) null);
 	}
 
 	/**
@@ -255,7 +253,7 @@ public class CommitUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void getRefWithEmptyRefName() throws Exception {
-		CommitUtils.getRef(new FileRepository(testRepo), "");
+		CommitUtils.getRef(new FileRepositoryBuilder().setGitDir(testRepo).build(), "");
 	}
 
 	/**
@@ -346,7 +344,7 @@ public class CommitUtilsTest extends GitTestCase {
 				return null;
 			}
 		};
-		assertNull(CommitUtils.getRef(new FileRepository(testRepo), ref));
+		assertNull(CommitUtils.getRef(new FileRepositoryBuilder().setGitDir(testRepo).build(), ref));
 	}
 
 	/**
@@ -390,7 +388,7 @@ public class CommitUtilsTest extends GitTestCase {
 				return null;
 			}
 		};
-		CommitUtils.getRef(new FileRepository(testRepo), ref);
+		CommitUtils.getRef(new FileRepositoryBuilder().setGitDir(testRepo).build(), ref);
 	}
 
 	/**
@@ -400,7 +398,7 @@ public class CommitUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = GitException.class)
 	public void getBaseWithZeroId() throws Exception {
-		CommitUtils.getBase(new FileRepository(testRepo), ObjectId.zeroId());
+		CommitUtils.getBase(new FileRepositoryBuilder().setGitDir(testRepo).build(), ObjectId.zeroId());
 	}
 
 	/**
@@ -410,7 +408,7 @@ public class CommitUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = GitException.class)
 	public void getCommitWithZeroId() throws Exception {
-		CommitUtils.getCommit(new FileRepository(testRepo), ObjectId.zeroId());
+		CommitUtils.getCommit(new FileRepositoryBuilder().setGitDir(testRepo).build(), ObjectId.zeroId());
 	}
 
 	/**
@@ -443,7 +441,7 @@ public class CommitUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void getLastCommitNullPath() throws Exception {
-		CommitUtils.getLastCommit(new FileRepository(testRepo), null);
+		CommitUtils.getLastCommit(new FileRepositoryBuilder().setGitDir(testRepo).build(), null);
 	}
 
 	/**
@@ -453,7 +451,7 @@ public class CommitUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void getLastCommitEmptyPath() throws Exception {
-		CommitUtils.getLastCommit(new FileRepository(testRepo), "");
+		CommitUtils.getLastCommit(new FileRepositoryBuilder().setGitDir(testRepo).build(), "");
 	}
 
 	/**
@@ -464,7 +462,7 @@ public class CommitUtilsTest extends GitTestCase {
 	@Test(expected = IllegalArgumentException.class)
 	public void getLastCommitNullRevision() throws Exception {
 		CommitUtils
-				.getLastCommit(new FileRepository(testRepo), null, "d/f.txt");
+				.getLastCommit(new FileRepositoryBuilder().setGitDir(testRepo).build(), null, "d/f.txt");
 	}
 
 	/**
@@ -474,6 +472,6 @@ public class CommitUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void getLastCommitEmptyRevision() throws Exception {
-		CommitUtils.getLastCommit(new FileRepository(testRepo), "", "d/f.txt");
+		CommitUtils.getLastCommit(new FileRepositoryBuilder().setGitDir(testRepo).build(), "", "d/f.txt");
 	}
 }

--- a/org.gitective.core/src/test/java/org/gitective/tests/CursorTest.java
+++ b/org.gitective.core/src/test/java/org/gitective/tests/CursorTest.java
@@ -26,13 +26,10 @@ import java.util.List;
 
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.filter.RevFilter;
-import org.eclipse.jgit.storage.file.FileRepository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.gitective.core.CommitFinder;
 import org.gitective.core.CommitUtils;
-import org.gitective.core.filter.commit.AndCommitFilter;
-import org.gitective.core.filter.commit.CommitCursorFilter;
-import org.gitective.core.filter.commit.CommitLimitFilter;
-import org.gitective.core.filter.commit.CommitListFilter;
+import org.gitective.core.filter.commit.*;
 import org.junit.Test;
 
 /**
@@ -61,7 +58,7 @@ public class CursorTest extends GitTestCase {
 				limit, bucket));
 		service.setFilter(cursor);
 		int chunks = 0;
-		RevCommit commit = CommitUtils.getHead(new FileRepository(testRepo));
+		RevCommit commit = CommitUtils.getHead(new FileRepositoryBuilder().setGitDir(testRepo).build());
 		while (commit != null) {
 			service.findFrom(commit);
 			assertEquals(limit.getLimit(), bucket.getCommits().size());

--- a/org.gitective.core/src/test/java/org/gitective/tests/GitExceptionTest.java
+++ b/org.gitective.core/src/test/java/org/gitective/tests/GitExceptionTest.java
@@ -23,7 +23,8 @@ package org.gitective.tests;
 
 import java.io.IOException;
 
-import org.eclipse.jgit.storage.file.FileRepository;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.gitective.core.GitException;
 import org.junit.Test;
 
@@ -41,7 +42,7 @@ public class GitExceptionTest extends GitTestCase {
 	public void constructors() throws IOException {
 		String message = "test";
 		NullPointerException cause = new NullPointerException();
-		FileRepository repo = new FileRepository(testRepo);
+		Repository repo = new FileRepositoryBuilder().setGitDir(testRepo).build();
 
 		GitException exception = new GitException(message, repo);
 		assertEquals(repo, exception.getRepository());

--- a/org.gitective.core/src/test/java/org/gitective/tests/LastCommitDiffFilterTest.java
+++ b/org.gitective.core/src/test/java/org/gitective/tests/LastCommitDiffFilterTest.java
@@ -24,7 +24,7 @@ package org.gitective.tests;
 import java.util.Map;
 
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.eclipse.jgit.storage.file.FileRepository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.gitective.core.CommitFinder;
 import org.gitective.core.CommitUtils;
 import org.gitective.core.filter.commit.LastCommitDiffFilter;
@@ -113,8 +113,7 @@ public class LastCommitDiffFilterTest extends GitTestCase {
 		checkout("master");
 		RevCommit commit3 = add("b.txt", "b");
 		merge("b1");
-		assertFalse(commit3.equals(CommitUtils.getHead(new FileRepository(
-				testRepo))));
+		assertFalse(commit3.equals(CommitUtils.getHead(new FileRepositoryBuilder().setGitDir(testRepo).build())));
 
 		LastCommitDiffFilter filter = new LastCommitDiffFilter();
 		new CommitFinder(testRepo).setFilter(filter).find();

--- a/org.gitective.core/src/test/java/org/gitective/tests/LatestTest.java
+++ b/org.gitective.core/src/test/java/org/gitective/tests/LatestTest.java
@@ -22,7 +22,7 @@
 package org.gitective.tests;
 
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.eclipse.jgit.storage.file.FileRepository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.gitective.core.CommitUtils;
 import org.junit.Test;
 
@@ -39,9 +39,9 @@ public class LatestTest extends GitTestCase {
 	@Test
 	public void latest() throws Exception {
 		RevCommit commit = add("file.txt", "content");
-		assertEquals(commit, CommitUtils.getHead(new FileRepository(testRepo)));
+		assertEquals(commit, CommitUtils.getHead(new FileRepositoryBuilder().setGitDir(testRepo).build()));
 		assertEquals(commit,
-				CommitUtils.getMaster(new FileRepository(testRepo)));
+				CommitUtils.getMaster(new FileRepositoryBuilder().setGitDir(testRepo).build()));
 	}
 
 	/**
@@ -50,7 +50,7 @@ public class LatestTest extends GitTestCase {
 	 * @throws Exception
 	 */
 	public void latestOnEmptyRepository() throws Exception {
-		assertNull(CommitUtils.getHead(new FileRepository(testRepo)));
+		assertNull(CommitUtils.getHead(new FileRepositoryBuilder().setGitDir(testRepo).build()));
 	}
 
 	/**
@@ -62,6 +62,6 @@ public class LatestTest extends GitTestCase {
 	public void byId() throws Exception {
 		RevCommit commit = add("file.txt", "content");
 		assertEquals(commit,
-				CommitUtils.getCommit(new FileRepository(testRepo), commit));
+				CommitUtils.getCommit(new FileRepositoryBuilder().setGitDir(testRepo).build(), commit));
 	}
 }

--- a/org.gitective.core/src/test/java/org/gitective/tests/MultiRepoTest.java
+++ b/org.gitective.core/src/test/java/org/gitective/tests/MultiRepoTest.java
@@ -24,7 +24,7 @@ package org.gitective.tests;
 import java.io.File;
 
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.eclipse.jgit.storage.file.FileRepository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.gitective.core.CommitFinder;
 import org.gitective.core.filter.commit.CommitCountFilter;
 import org.junit.Test;
@@ -42,7 +42,7 @@ public class MultiRepoTest extends GitTestCase {
 	@Test
 	public void constructors() throws Exception {
 		new CommitFinder(testRepo);
-		new CommitFinder(new FileRepository(testRepo));
+		new CommitFinder(new FileRepositoryBuilder().setGitDir(testRepo).build());
 		new CommitFinder(testRepo.getAbsolutePath());
 	}
 

--- a/org.gitective.core/src/test/java/org/gitective/tests/TreeUtilsTest.java
+++ b/org.gitective.core/src/test/java/org/gitective/tests/TreeUtilsTest.java
@@ -21,29 +21,21 @@
  */
 package org.gitective.tests;
 
-import static org.eclipse.jgit.lib.FileMode.REGULAR_FILE;
-import static org.eclipse.jgit.lib.FileMode.TREE;
-
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.eclipse.jgit.lib.AnyObjectId;
-import org.eclipse.jgit.lib.Constants;
-import org.eclipse.jgit.lib.FileMode;
-import org.eclipse.jgit.lib.ObjectId;
-import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.lib.*;
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.eclipse.jgit.storage.file.FileRepository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.eclipse.jgit.treewalk.TreeWalk;
 import org.gitective.core.BlobUtils;
 import org.gitective.core.TreeUtils;
 import org.gitective.core.TreeUtils.ITreeVisitor;
 import org.junit.Test;
+
+import static org.eclipse.jgit.lib.FileMode.REGULAR_FILE;
+import static org.eclipse.jgit.lib.FileMode.TREE;
 
 /**
  * Unit tests of {@link TreeUtils}
@@ -73,7 +65,7 @@ public class TreeUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void withParentsNullId() throws IOException {
-		TreeUtils.withParents(new FileRepository(testRepo), (ObjectId) null);
+		TreeUtils.withParents(new FileRepositoryBuilder().setGitDir(testRepo).build(), (ObjectId) null);
 	}
 
 	/**
@@ -83,7 +75,7 @@ public class TreeUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void withParentsNullRevision() throws IOException {
-		TreeUtils.withParents(new FileRepository(testRepo), (String) null);
+		TreeUtils.withParents(new FileRepositoryBuilder().setGitDir(testRepo).build(), (String) null);
 	}
 
 	/**
@@ -93,7 +85,7 @@ public class TreeUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void withParentsEmptyRevision() throws IOException {
-		TreeUtils.withParents(new FileRepository(testRepo), "");
+		TreeUtils.withParents(new FileRepositoryBuilder().setGitDir(testRepo).build(), "");
 	}
 
 	/**
@@ -104,7 +96,7 @@ public class TreeUtilsTest extends GitTestCase {
 	@Test
 	public void diffWithNoParents() throws Exception {
 		RevCommit commit = add("test.txt", "content");
-		Repository repo = new FileRepository(testRepo);
+		Repository repo = new FileRepositoryBuilder().setGitDir(testRepo).build();
 		TreeWalk walk = TreeUtils.diffWithParents(repo, Constants.HEAD);
 		assertNotNull(walk);
 		assertEquals(2, walk.getTreeCount());
@@ -123,7 +115,7 @@ public class TreeUtilsTest extends GitTestCase {
 	 */
 	@Test
 	public void diffWithOneParent() throws Exception {
-		Repository repo = new FileRepository(testRepo);
+		Repository repo = new FileRepositoryBuilder().setGitDir(testRepo).build();
 		RevCommit commit1 = add("test.txt", "content");
 		RevCommit commit2 = add("test.txt", "content2");
 		TreeWalk walk = TreeUtils.diffWithParents(repo, Constants.HEAD);
@@ -145,7 +137,7 @@ public class TreeUtilsTest extends GitTestCase {
 	 */
 	@Test
 	public void diffRevisions() throws Exception {
-		Repository repo = new FileRepository(testRepo);
+		Repository repo = new FileRepositoryBuilder().setGitDir(testRepo).build();
 		RevCommit commit1 = add("test.txt", "content");
 		RevCommit commit2 = add("test.txt", "content2");
 		TreeWalk walk = TreeUtils.diffWithCommits(repo,
@@ -168,7 +160,7 @@ public class TreeUtilsTest extends GitTestCase {
 	 */
 	@Test
 	public void diffCommits() throws Exception {
-		Repository repo = new FileRepository(testRepo);
+		Repository repo = new FileRepositoryBuilder().setGitDir(testRepo).build();
 		RevCommit commit1 = add("test.txt", "content");
 		RevCommit commit2 = add("test.txt", "content2");
 		TreeWalk walk = TreeUtils.diffWithCommits(repo, commit1, commit2);
@@ -206,7 +198,7 @@ public class TreeUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void withCommitsNullIds() throws IOException {
-		TreeUtils.withCommits(new FileRepository(testRepo), (ObjectId[]) null);
+		TreeUtils.withCommits(new FileRepositoryBuilder().setGitDir(testRepo).build(), (ObjectId[]) null);
 	}
 
 	/**
@@ -216,7 +208,7 @@ public class TreeUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void withCommitsNullRevision() throws IOException {
-		TreeUtils.withCommits(new FileRepository(testRepo), (String[]) null);
+		TreeUtils.withCommits(new FileRepositoryBuilder().setGitDir(testRepo).build(), (String[]) null);
 	}
 
 	/**
@@ -226,7 +218,7 @@ public class TreeUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void withCommitsEmptyRevision() throws IOException {
-		TreeUtils.withCommits(new FileRepository(testRepo), new String[0]);
+		TreeUtils.withCommits(new FileRepositoryBuilder().setGitDir(testRepo).build(), new String[0]);
 	}
 
 	/**
@@ -236,7 +228,7 @@ public class TreeUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void withCommitsEmptyCommits() throws IOException {
-		TreeUtils.withCommits(new FileRepository(testRepo), new ObjectId[0]);
+		TreeUtils.withCommits(new FileRepositoryBuilder().setGitDir(testRepo).build(), new ObjectId[0]);
 	}
 
 	/**
@@ -263,7 +255,7 @@ public class TreeUtilsTest extends GitTestCase {
 	@Test(expected = IllegalArgumentException.class)
 	public void getIdNullCommitId() throws IOException {
 		TreeUtils
-				.getId(new FileRepository(testRepo), (ObjectId) null, "folder");
+				.getId(new FileRepositoryBuilder().setGitDir(testRepo).build(), (ObjectId) null, "folder");
 	}
 
 	/**
@@ -273,7 +265,7 @@ public class TreeUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void getIdNullRevision() throws IOException {
-		TreeUtils.getId(new FileRepository(testRepo), (String) null, "folder");
+		TreeUtils.getId(new FileRepositoryBuilder().setGitDir(testRepo).build(), (String) null, "folder");
 	}
 
 	/**
@@ -283,7 +275,7 @@ public class TreeUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void getIdEmptyRevision() throws IOException {
-		TreeUtils.getId(new FileRepository(testRepo), "", "folder");
+		TreeUtils.getId(new FileRepositoryBuilder().setGitDir(testRepo).build(), "", "folder");
 	}
 
 	/**
@@ -293,7 +285,7 @@ public class TreeUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void getIdNullPath1() throws IOException {
-		TreeUtils.getId(new FileRepository(testRepo), ObjectId.zeroId(), null);
+		TreeUtils.getId(new FileRepositoryBuilder().setGitDir(testRepo).build(), ObjectId.zeroId(), null);
 	}
 
 	/**
@@ -303,7 +295,7 @@ public class TreeUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void getIdNullPath2() throws IOException {
-		TreeUtils.getId(new FileRepository(testRepo), Constants.MASTER, null);
+		TreeUtils.getId(new FileRepositoryBuilder().setGitDir(testRepo).build(), Constants.MASTER, null);
 	}
 
 	/**
@@ -313,7 +305,7 @@ public class TreeUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void getIdEmptyPath1() throws IOException {
-		TreeUtils.getId(new FileRepository(testRepo), ObjectId.zeroId(), "");
+		TreeUtils.getId(new FileRepositoryBuilder().setGitDir(testRepo).build(), ObjectId.zeroId(), "");
 	}
 
 	/**
@@ -323,7 +315,7 @@ public class TreeUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void getIdEmptyPath2() throws IOException {
-		TreeUtils.getId(new FileRepository(testRepo), Constants.MASTER, "");
+		TreeUtils.getId(new FileRepositoryBuilder().setGitDir(testRepo).build(), Constants.MASTER, "");
 	}
 
 	/**
@@ -333,7 +325,7 @@ public class TreeUtilsTest extends GitTestCase {
 	 */
 	@Test
 	public void getIdWithCommit() throws Exception {
-		Repository repo = new FileRepository(testRepo);
+		Repository repo = new FileRepositoryBuilder().setGitDir(testRepo).build();
 		RevCommit commit = add("d1/f1.txt", "content");
 		assertNull(TreeUtils.getId(repo, commit, "d2/f1.txt"));
 		assertNull(TreeUtils.getId(repo, commit, "d1/f1.txt"));
@@ -351,7 +343,7 @@ public class TreeUtilsTest extends GitTestCase {
 	 */
 	@Test
 	public void getIdWithRevision() throws Exception {
-		Repository repo = new FileRepository(testRepo);
+		Repository repo = new FileRepositoryBuilder().setGitDir(testRepo).build();
 		RevCommit commit = add("d1/f1.txt", "content");
 		assertNull(TreeUtils.getId(repo, Constants.MASTER, "d2/f1.txt"));
 		assertNull(TreeUtils.getId(repo, Constants.MASTER, "d1/f1.txt"));
@@ -383,7 +375,7 @@ public class TreeUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void visitNullTreeId() throws IOException {
-		TreeUtils.visit(new FileRepository(testRepo), null, new ITreeVisitor() {
+		TreeUtils.visit(new FileRepositoryBuilder().setGitDir(testRepo).build(), null, new ITreeVisitor() {
 
 			public boolean accept(FileMode mode, String path, String name,
 					AnyObjectId id) {
@@ -399,7 +391,7 @@ public class TreeUtilsTest extends GitTestCase {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void visitNullVisitor() throws IOException {
-		TreeUtils.visit(new FileRepository(testRepo), ObjectId.zeroId(), null);
+		TreeUtils.visit(new FileRepositoryBuilder().setGitDir(testRepo).build(), ObjectId.zeroId(), null);
 	}
 
 	/**
@@ -416,7 +408,7 @@ public class TreeUtilsTest extends GitTestCase {
 		final AtomicInteger folders = new AtomicInteger(0);
 		final List<String> fullPaths = new ArrayList<String>();
 		final Set<AnyObjectId> ids = new HashSet<AnyObjectId>();
-		assertTrue(TreeUtils.visit(new FileRepository(testRepo),
+		assertTrue(TreeUtils.visit(new FileRepositoryBuilder().setGitDir(testRepo).build(),
 				commit.getTree(), new ITreeVisitor() {
 
 					public boolean accept(FileMode mode, String path,


### PR DESCRIPTION
The main change is in avoiding new FileRepository(path), and instead using FileRepositoryBuilder.
